### PR TITLE
Cache models

### DIFF
--- a/src/cmp/PromptForm.tsx
+++ b/src/cmp/PromptForm.tsx
@@ -66,7 +66,7 @@ export function PromptForm({ editMode, editMessageId }: Props) {
         providers.map(async (provider) => {
           try {
             const models = await provider.getModels()
-            return [provider.name, models] as [string, string[]]
+            return [provider.name, models ?? []] as [string, string[]]
           } catch {
             return [provider.name, []] as [string, string[]]
           }
@@ -139,7 +139,7 @@ export function PromptForm({ editMode, editMessageId }: Props) {
         <Form.Dropdown
           id="model-selector"
           title="Model"
-          value={selectedModelId}
+          value={selectedModelId ?? undefined}
           onChange={(newValue) => setSelectedModelId(newValue as ModelId)}
         >
           {providers.map((provider) => (

--- a/src/lib/llm/types.ts
+++ b/src/lib/llm/types.ts
@@ -3,7 +3,7 @@ import { ChatMessage } from '../../types'
 
 export interface LLMProvider<T extends string = string> {
   name: string
-  models?: readonly T[]
+  models?: readonly T[] | null
   searchModels?: readonly T[]
   weakModel: T
   isModel: (modelId: string) => Promise<boolean>


### PR DESCRIPTION
This pull request introduces caching for Shopify models to improve performance and updates the `PromptForm` component to handle null or undefined values more robustly. Additionally, it modifies the `LLMProvider` interface to allow `null` for the `models` property. Below is a summary of the most important changes:

### Caching improvements for Shopify models:

* Added a caching mechanism in `src/lib/llm/providers/shopify.ts` to store Shopify models and avoid redundant API calls. This includes the `getCachedShopifyModels` function and updates to use it in `checkIsModel` and the `shopifyProvider` object. [[1]](diffhunk://#diff-ba4c6f293a775a53f5ea4dbe9bc6f56277ce4e13b766fff6db69f85696214a34R14-R29) [[2]](diffhunk://#diff-ba4c6f293a775a53f5ea4dbe9bc6f56277ce4e13b766fff6db69f85696214a34L205-R230)

### Robust handling of null/undefined values in `PromptForm`:

* Updated the `PromptForm` component in `src/cmp/PromptForm.tsx` to handle cases where `provider.getModels()` returns `null` by defaulting to an empty array.
* Modified the `value` property of the model selector dropdown to use `undefined` when `selectedModelId` is `null`, ensuring compatibility with the form library.

### Type updates:

* Updated the `LLMProvider` interface in `src/lib/llm/types.ts` to allow the `models` property to be `null`, reflecting the new caching behavior.