### PR TITLE
Persist selected model across sessions

### DIFF
--- a/src/lib/chat-state.ts
+++ b/src/lib/chat-state.ts
@@ -274,12 +274,7 @@ export const setQuery = (query: string) => useStore.set({ query })
 async function load() {
   useStore.set({ loading: true })
   const loaded = await loadState()
-
-  // Handle invalid model ID
-  if (!isValidModelId(loaded.selectedModelId)) {
-    loaded.selectedModelId = DEFAULT_MODEL_ID
-  }
-
+  
   useStore.set({
     persistentState: loaded,
     initializing: false,


### PR DESCRIPTION
### What\nThis PR ensures the extension remembers the last selected model.\n\n### How\n1. When you change the model, we now always store that value in the global persistent state _as well as_ in the active session.\n2. Removed the premature model-ID validation during state load so the saved value isn’t overwritten before the models list is fetched.\n\n### Why\nPreviously the extension always defaulted to the first model after restart because the stored model was replaced with the default during initialization. This fixes that.